### PR TITLE
Only read image dimensions from known image hosts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,16 @@ const emoji = Object.entries(emojiRaw).map(function(e) { e[0] = e[1].shortname.s
 const emojiMappings = require('../data/emojiMappings.json');
 const emptyImage = 'data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
 
+// Reading an image's dimensions means fetching it from the server doing the
+// rendering, so we only do it for image hosts we know and expect. Images on
+// any other host still render, just without height and width attributes.
+const imageProbeHosts = [
+    'i.imgur.com',
+    'media.stores.com',
+    'res.cloudinary.com',
+    'static.meh.com'
+];
+
 for (const key in emoji) {
     const _emoji = emoji[key];
     _emoji.stemmedAliases = _emoji.shortname_alternates.map(a => natural.PorterStemmer.stem(a.replace(/:/g, '').toLowerCase()));
@@ -703,6 +713,18 @@ exports.render = function(markdown, options, callback) {
 
                 if (url.startsWith('//')) {
                     url = `https:${url}`;
+                }
+
+                let hostname;
+
+                try {
+                    hostname = new URL(url).hostname.toLowerCase();
+                } catch {
+                    return;
+                }
+
+                if (!imageProbeHosts.includes(hostname)) {
+                    return;
                 }
 
                 try {

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
         "test": "node --test --test-force-exit --test-reporter=spec",
         "test:only": "node --test --test-force-exit --test-only --test-reporter=spec"
     },
-    "version": "3.0.0"
+    "version": "3.0.1"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert');
+const http = require('node:http');
 const test = require('node:test');
 
 const mehdown = require('../lib');
@@ -512,6 +513,29 @@ test('detect image sizes', { concurrency: true }, async (t) => {
     t.test('no images', async () => {
         const html = await render('just some plain text', { detectImageSizes: true });
         assert.strictEqual(html, '<p>just some plain text</p>');
+    });
+
+    t.test('does not request images hosted on loopback addresses', async () => {
+        let requested = false;
+
+        const server = http.createServer((req, res) => {
+            requested = true;
+            res.writeHead(404);
+            res.end();
+        });
+
+        await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+        const port = server.address().port;
+
+        try {
+            const html = await render(`http://127.0.0.1:${port}/image.png`, { detectImageSizes: true });
+
+            assert.strictEqual(requested, false, 'expected no request to the loopback host');
+            assert.strictEqual(html, `<p><img src="http://127.0.0.1:${port}/image.png" /></p>`);
+        } finally {
+            server.close();
+        }
     });
 
     t.test('images', async () => {


### PR DESCRIPTION
Detecting an image's dimensions fetches that image from whichever server is doing the rendering. Until now any URL in a post could make the renderer issue an outbound request, which is more reach than a Markdown renderer needs — and it's slow. An unreachable host holds the render open for the probe's full 10s connect timeout, and images are probed in parallel, so a post full of dead links stalls on the slowest one.

This restricts probing to a small list of image hosts we actually expect:

```js
const imageProbeHosts = [
    'i.imgur.com',
    'media.stores.com',
    'res.cloudinary.com',
    'static.meh.com'
];
```

Images on any other host still render, just without `height` and `width` — the same behaviour as an image that fails to probe today.

### Picking the list

Sampled real forum content rather than guessing. The most recent 300 topics contain 81 images across five hosts, ~75% of them on our own CDN. `i.imgur.com` dominates older content (55 of 138 images in an older sample), so it's included.

One host was left off deliberately: `dj5zo597wtsux.cloudfront.net` appears 33 times in recent posts, but `media.stores.com` resolves to `d2b8wt72ktn9a2` and `static.meh.com` to `d3306cnzm6n89c`, so I couldn't confirm that third distribution is ours. **If it is, it should be added** — otherwise those posts lose their dimensions.

### Tests

New test stands up a real local HTTP server and asserts the renderer never contacts it. Written first and confirmed failing (`true !== false`) before the change. It asserts on the request never happening rather than on render timing, so it won't flake in CI.

The existing `res.cloudinary.com` assertions still expect `height="528" width="528"`, which confirms probing is restricted rather than disabled.

347 pass, 0 fail, ESLint clean. The two broken-image cases drop from 217ms and 367ms to ~10ms each, since neither host is contacted now.

### Release

Version bumped to **3.0.1** — `publish.yml` publishes whatever is in package.json and 3.0.0 is already on npm. Consumers pin `~3.0.0`, which accepts it.