### PR TITLE
Expand the image hosts we read dimensions from

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,19 +17,12 @@ const emoji = Object.entries(emojiRaw).map(function(e) { e[0] = e[1].shortname.s
 const emojiMappings = require('../data/emojiMappings.json');
 const emptyImage = 'data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
 
-// Reading an image's dimensions means fetching it from the server doing the
-// rendering, so we only do it for image hosts we know and expect. Images on
-// any other host still render, just without height and width attributes.
-//
-// imageProbeDomains also covers subdomains, for hosts that shard across many of
-// them. Matching requires a leading dot so that a domain can only be matched at
-// a label boundary, never as a trailing substring of some other host.
-const imageProbeDomains = [
-    'giphy.com',
-    'tenor.com'
-];
-
+// Reading an image's dimensions fetches it server-side, so only these hosts get
+// probed. Anything else still renders, just without height and width. A leading
+// dot matches the domain and its subdomains; every other entry matches exactly.
 const imageProbeHosts = [
+    '.giphy.com',
+    '.tenor.com',
     'd2b8wt72ktn9a2.cloudfront.net',
     'i.imgur.com',
     'i.ytimg.com',
@@ -454,6 +447,14 @@ exports.bbcode = {
 
 exports.commandRegExp = /^\/(\w+)[ ]*(.*)/gim;
 
+// Entries are escaped and the pattern is anchored, so a listed host only matches
+// a whole hostname at a label boundary, never part of an unrelated domain.
+exports.imageProbeHostRegExp = new RegExp(`^(?:${imageProbeHosts.map(host => {
+    const escaped = host.replace(/^\./, '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    return host.startsWith('.') ? `(?:[^.]+\\.)*${escaped}` : escaped;
+}).join('|')})$`);
+
 exports.html = {
     convertRelativeUrlsToAbsoluteUrls: function(html, baseUrl) {
         return relToAbs.convert(html, baseUrl);
@@ -737,7 +738,7 @@ exports.render = function(markdown, options, callback) {
                     return;
                 }
 
-                if (!imageProbeHosts.includes(hostname) && !imageProbeDomains.some(domain => hostname === domain || hostname.endsWith(`.${domain}`))) {
+                if (!exports.imageProbeHostRegExp.test(hostname)) {
                     return;
                 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const textify = require('textify');
 const youtubeSearch = require('youtube-search');
 
 const emojiRaw = require('../data/emoji.json');
-const emoji = Object.entries(emojiRaw).map(function(e) { e[0] = e[1].shortname.slice(1, -1); return e; }).reduce(function(o, e) { o[e[0]] = e[1]; return o;}, {});
+const emoji = Object.entries(emojiRaw).map(e => { e[0] = e[1].shortname.slice(1, -1); return e; }).reduce((o, e) => { o[e[0]] = e[1]; return o; }, {});
 const emojiMappings = require('../data/emojiMappings.json');
 const emptyImage = 'data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
 
@@ -32,6 +32,14 @@ const imageProbeHosts = [
     'substackcdn.com',
     'upload.wikimedia.org'
 ];
+
+// Entries are escaped and the pattern is anchored, so a listed host only matches
+// a whole hostname at a label boundary, never part of an unrelated domain.
+const imageProbeHostRegExp = new RegExp(`^(?:${imageProbeHosts.map(host => {
+    const escaped = host.replace(/^\./, '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    return host.startsWith('.') ? `(?:[^.]+\\.)*${escaped}` : escaped;
+}).join('|')})$`);
 
 for (const key in emoji) {
     const _emoji = emoji[key];
@@ -77,10 +85,10 @@ function _leet(args, callback) {
 
 const commands = {
     '1337': _leet,
-    '8ball': function(args, callback) {
+    '8ball'(args, callback) {
         _eightball('8ball', args, callback);
     },
-    coinflip: function(args, callback) {
+    coinflip(args, callback) {
         const responses = [
             'HEADS it is!',
             'You landed on HEADS!',
@@ -118,13 +126,13 @@ const commands = {
 
         callback(null, `/coinflip ${args}\n ${answer}`);
     },
-    concerned: function(args, callback) {
+    concerned(args, callback) {
         callback(null, 'ಠ_ಠ');
     },
-    eightball: function(args, callback) {
+    eightball(args, callback) {
         _eightball('eightball', args, callback);
     },
-    emojify: function(args, callback) {
+    emojify(args, callback) {
         // This command requires arguments.
         if (!args) {
             return callback();
@@ -134,7 +142,7 @@ const commands = {
 
         tokens.forEach(t => {
             // Check the static Emoji mappings blacklist
-            if (emojiMappings.blacklist.indexOf(t.toLowerCase()) !== -1) {
+            if (emojiMappings.blacklist.includes(t.toLowerCase())) {
                 return;
             }
 
@@ -166,7 +174,7 @@ const commands = {
                     continue;
                 }
 
-                if (_emoji.stemmedAliases.indexOf(stem) !== -1) {
+                if (_emoji.stemmedAliases.includes(stem)) {
                     args = args.replace(new RegExp(`\\b${t}\\b(?!:)`, 'g'), emoji[key].shortname);
                     return;
                 }
@@ -176,7 +184,7 @@ const commands = {
             for (const key in emoji) {
                 const _emoji = emoji[key];
 
-                if (_emoji.stemmedKeywords.indexOf(stem) !== -1) {
+                if (_emoji.stemmedKeywords.includes(stem)) {
                     key.split('_').forEach(shortNameToken => {
                         shortNameToken = natural.PorterStemmer.stem(shortNameToken.toLowerCase());
 
@@ -191,7 +199,7 @@ const commands = {
 
         callback(null, args);
     },
-    flip: function(args, callback) {
+    flip(args, callback) {
         // This command requires arguments.
         if (!args) {
             return callback();
@@ -199,7 +207,7 @@ const commands = {
 
         callback(null, flip(args));
     },
-    giphy: function(args, callback) {
+    giphy(args, callback) {
         // This command requires arguments.
         if (!args) {
             return callback();
@@ -211,7 +219,7 @@ const commands = {
             return callback();
         }
 
-        request.get(`http://api.giphy.com/v1/gifs/search?q=${encodeURIComponent(args)}&api_key=${process.env.GIPHY_API_KEY}`, { json: true }, function(err, res, body) {
+        request.get(`http://api.giphy.com/v1/gifs/search?q=${encodeURIComponent(args)}&api_key=${process.env.GIPHY_API_KEY}`, { json: true }, (err, res, body) => {
             if (err) {
                 return callback();
             }
@@ -226,7 +234,7 @@ const commands = {
             callback(null, `/giphy ${args}\n${gif.images.original.url}`);
         });
     },
-    google: function(args, callback) {
+    google(args, callback) {
         // This command requires arguments.
         if (!args) {
             return callback();
@@ -238,7 +246,7 @@ const commands = {
             return callback();
         }
 
-        request.get(`https://www.googleapis.com/customsearch/v1?cx=001016559301879871327:usuoorwmjkw&key=${process.env.GOOGLE_API_KEY}&q=${encodeURIComponent(args)}&safe=high`, { json: true }, function(err, _res, body) {
+        request.get(`https://www.googleapis.com/customsearch/v1?cx=001016559301879871327:usuoorwmjkw&key=${process.env.GOOGLE_API_KEY}&q=${encodeURIComponent(args)}&safe=high`, { json: true }, (err, _res, body) => {
             if (err) {
                 return callback();
             }
@@ -252,13 +260,13 @@ const commands = {
             callback(null, `/google ${args}\n${item.title}\n${item.link}`);
         });
     },
-    image: function(args, callback) {
+    image(args, callback) {
         // This command requires arguments.
         if (!args) {
             return callback();
         }
 
-        request.get(`https://www.googleapis.com/customsearch/v1?cx=001016559301879871327:usuoorwmjkw&key=${process.env.GOOGLE_API_KEY}&q=${encodeURIComponent(args)}&safe=high&searchType=image`, { json: true }, function(err, _res, body) {
+        request.get(`https://www.googleapis.com/customsearch/v1?cx=001016559301879871327:usuoorwmjkw&key=${process.env.GOOGLE_API_KEY}&q=${encodeURIComponent(args)}&safe=high&searchType=image`, { json: true }, (err, _res, body) => {
             if (err) {
                 return callback();
             }
@@ -270,7 +278,7 @@ const commands = {
             callback(null, `/image ${args}\n![$args](${body.items[0].link})`);
         });
     },
-    jumble: function(args, callback){
+    jumble(args, callback) {
         // This command requires arguments.
         if (!args) {
             return callback();
@@ -279,11 +287,11 @@ const commands = {
         callback(null, textify.texturize(args));
     },
     l33t: _leet,
-    labrat: function(args, callback) {
+    labrat(args, callback) {
         callback(null, 'https://res.cloudinary.com/mediocre/image/upload/v1537473791/mijjibf0vxdx79wtqrjh.png');
     },
     leet: _leet,
-    lolspeak: function(args, callback) {
+    lolspeak(args, callback) {
         // This command requires arguments.
         if (!args) {
             return callback();
@@ -291,7 +299,7 @@ const commands = {
 
         callback(null, lolspeak(args));
     },
-    piglatin: function(args, callback) {
+    piglatin(args, callback) {
         // This command requires arguments.
         if (!args) {
             return callback();
@@ -299,7 +307,7 @@ const commands = {
 
         callback(null, textify.toPigLatin(args));
     },
-    reverse: function(args, callback) {
+    reverse(args, callback) {
         // This command requires arguments.
         if (!args) {
             return callback();
@@ -307,7 +315,7 @@ const commands = {
 
         callback(null, textify.reverse(args));
     },
-    roll: function(args, callback) {
+    roll(args, callback) {
         const dice = new roll();
         const _args = args;
 
@@ -366,7 +374,7 @@ const commands = {
 
         callback(null, message);
     },
-    rot13: function(args, callback) {
+    rot13(args, callback) {
         // This command requires arguments.
         if (!args) {
             return callback();
@@ -374,17 +382,17 @@ const commands = {
 
         callback(null, textify.rot13(args));
     },
-    shrug: function(args, callback) {
+    shrug(args, callback) {
         // https://xkcd.com/1638/
         callback(null, '¯\\\\\\_(ツ)\\_/¯');
     },
-    tableflip: function(args, callback) {
+    tableflip(args, callback) {
         callback(null, '(╯°□°）╯︵ ┻━┻');
     },
-    vintner: function(args, callback) {
+    vintner(args, callback) {
         callback(null, 'https://res.cloudinary.com/mediocre/image/upload/v1540480421/joddffo2zrhb1pzxz7le.png');
     },
-    youtube: function(args, callback) {
+    youtube(args, callback) {
         // This command requires arguments.
         if (!args) {
             return callback();
@@ -396,7 +404,7 @@ const commands = {
             return callback();
         }
 
-        youtubeSearch(args, { key: process.env.GOOGLE_API_KEY, type: 'video' }, function(err, results) {
+        youtubeSearch(args, { key: process.env.GOOGLE_API_KEY, type: 'video' }, (err, results) => {
             if (err) {
                 return callback();
             }
@@ -411,7 +419,7 @@ const commands = {
 };
 
 exports.bbcode = {
-    toMarkdown: function(bbcode) {
+    toMarkdown(bbcode) {
         let markdown = bbcode;
 
         // [b]
@@ -446,47 +454,30 @@ exports.bbcode = {
 
 exports.commandRegExp = /^\/(\w+)[ ]*(.*)/gim;
 
-// Entries are escaped and the pattern is anchored, so a listed host only matches
-// a whole hostname at a label boundary, never part of an unrelated domain.
-const imageProbeHostRegExp = new RegExp(`^(?:${imageProbeHosts.map(host => {
-    const escaped = host.replace(/^\./, '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-    return host.startsWith('.') ? `(?:[^.]+\\.)*${escaped}` : escaped;
-}).join('|')})$`);
-
 exports.html = {
-    convertRelativeUrlsToAbsoluteUrls: function(html, baseUrl) {
+    convertRelativeUrlsToAbsoluteUrls(html, baseUrl) {
         return relToAbs.convert(html, baseUrl);
     },
-    convertToLazyLoadedImages: function(html) {
-        let imgElements = exports.html.getElementsByTagName(html, 'img');
-
-        if (!imgElements?.length) {
-            return html;
-        }
-
-        // De-duplicate
-        imgElements = imgElements.filter((value, index, array) => array.indexOf(value) === index);
-
-        imgElements.forEach(function(imgElement) {
+    convertToLazyLoadedImages(html) {
+        for (const imgElement of new Set(exports.html.getElementsByTagName(html, 'img'))) {
             const height = exports.html.getAttributeValue(imgElement, 'height');
             const src = exports.html.getAttributeValue(imgElement, 'src');
             const width = exports.html.getAttributeValue(imgElement, 'width');
 
             // Only convert src to lazy loaded images if the img tag has height, src, and width attributes
             if (!height || !src || !width) {
-                return;
+                continue;
             }
 
             let lazyLoadImgElement = imgElement.replace('height="', 'data-height="').replace('width="', 'data-width="');
-            lazyLoadImgElement = lazyLoadImgElement.replace('src="', 'src="' + emptyImage + '" data-src="');
+            lazyLoadImgElement = lazyLoadImgElement.replace('src="', `src="${emptyImage}" data-src="`);
 
             html = html.replaceAll(imgElement, lazyLoadImgElement);
-        });
+        }
 
         return html;
     },
-    getAttributeValue: function(html, attribute) {
+    getAttributeValue(html, attribute) {
         const matches = html.match(new RegExp(attribute + '="([^"]+)'));
 
         if (!matches) {
@@ -495,14 +486,14 @@ exports.html = {
 
         return matches[1];
     },
-    getElementsByTagName: function(html, tag) {
-        return html.match(new RegExp('<' + tag + '[^>]*>', 'gi'));
+    getElementsByTagName(html, tag) {
+        return html.match(new RegExp(`<${tag}[^>]*>`, 'gi'));
     },
-    permalinkHeaders: function(html, icon = 'fa-link') {
+    permalinkHeaders(html, icon = 'fa-link') {
         // $0 - whole match, $1 - opening tag and content, $2 - opening tag name (to match the end tag), $3 - value of id attr, $4 - closing tag
         return html.replace(/(<(h\d)\s+id="([^"]+)">.+?)(<\/\2>)/gs,`$1<a class="permalink" href="#$3" title="Link"><i class="fa ${icon}"></i></a>$4`);
     },
-    removeAttribute: function(html, attribute) {
+    removeAttribute(html, attribute) {
         if (!html) {
             return;
         }
@@ -513,26 +504,16 @@ exports.html = {
             return html;
         }
 
-        return html.replace(attribute + '="' + matches[1] + '"', '');
+        return html.replace(`${attribute}="${matches[1]}"`, '');
     },
-    removeImageSizeAttributes: function(html) {
-        let imgElements = exports.html.getElementsByTagName(html, 'img');
-
-        if (!imgElements?.length) {
-            return html;
-        }
-
-        // De-duplicate
-        imgElements = imgElements.filter((value, index, array) => array.indexOf(value) === index);
-
-        imgElements.forEach(function(imgElement) {
-            let imgElementWithoutSizeAttributes = exports.html.removeAttribute(imgElement, 'height');
-            imgElementWithoutSizeAttributes = exports.html.removeAttribute(imgElementWithoutSizeAttributes, 'width');
+    removeImageSizeAttributes(html) {
+        for (const imgElement of new Set(exports.html.getElementsByTagName(html, 'img'))) {
+            const imgElementWithoutSizeAttributes = exports.html.removeAttribute(exports.html.removeAttribute(imgElement, 'height'), 'width');
 
             if (imgElement !== imgElementWithoutSizeAttributes) {
                 html = html.replaceAll(imgElement, imgElementWithoutSizeAttributes);
             }
-        });
+        }
 
         return html;
     }
@@ -547,7 +528,7 @@ exports.kalturaEmbedHtml = function(urlStr) {
 
     const matches = uri.href.match(/(?:https?:\/\/(?:.\.)?)?(?:kaltura\.com\/).*(?:\/partner_id\/)(\w+).*(?:\/uiconf_id\/)(\w+).*(?:\/entry_id\/)(\w+)(?:.*#t=(.*))?/i);
 
-    if (!matches || !matches[1] || !matches[2] || !matches[3]) {
+    if (!matches?.[1] || !matches?.[2] || !matches?.[3]) {
         return '';
     }
 
@@ -608,7 +589,7 @@ exports.render = function(markdown, options, callback) {
                 };
             });
 
-            async.forEachOf(commandMatches, function(commandMatch, index, callback) {
+            async.forEachOf(commandMatches, (commandMatch, index, callback) => {
                 const tokens = new RegExp(exports.commandRegExp.source, 'gim').exec(commandMatch);
 
                 // The command's name is captured in the first match.
@@ -642,7 +623,7 @@ exports.render = function(markdown, options, callback) {
 
                     callback();
                 });
-            }, function() {
+            }, () => {
                 markdown = lines.map(l => l.markdown).join('\n');
                 callback();
             });
@@ -698,16 +679,13 @@ exports.render = function(markdown, options, callback) {
                 return callback();
             }
 
-            let imgElements = exports.html.getElementsByTagName(html, 'img');
+            const imgElements = [...new Set(exports.html.getElementsByTagName(html, 'img'))];
 
-            if (!imgElements?.length) {
+            if (!imgElements.length) {
                 return callback();
             }
 
-            // De-duplicate
-            imgElements = imgElements.filter((value, index, array) => array.indexOf(value) === index);
-
-            async.each(imgElements, async function(imgElement) {
+            async.each(imgElements, async imgElement => {
                 const className = exports.html.getAttributeValue(imgElement, 'class');
 
                 // Skip emojis
@@ -755,7 +733,7 @@ exports.render = function(markdown, options, callback) {
                 } catch {
                     return;
                 }
-            }, function() {
+            }, () => {
                 callback();
             });
         },

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,11 +20,25 @@ const emptyImage = 'data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALA
 // Reading an image's dimensions means fetching it from the server doing the
 // rendering, so we only do it for image hosts we know and expect. Images on
 // any other host still render, just without height and width attributes.
+//
+// imageProbeDomains also covers subdomains, for hosts that shard across many of
+// them. Matching requires a leading dot so that a domain can only be matched at
+// a label boundary, never as a trailing substring of some other host.
+const imageProbeDomains = [
+    'giphy.com',
+    'tenor.com'
+];
+
 const imageProbeHosts = [
+    'd2b8wt72ktn9a2.cloudfront.net',
     'i.imgur.com',
+    'i.ytimg.com',
+    'm.media-amazon.com',
     'media.stores.com',
     'res.cloudinary.com',
-    'static.meh.com'
+    'static.meh.com',
+    'substackcdn.com',
+    'upload.wikimedia.org'
 ];
 
 for (const key in emoji) {
@@ -723,7 +737,7 @@ exports.render = function(markdown, options, callback) {
                     return;
                 }
 
-                if (!imageProbeHosts.includes(hostname)) {
+                if (!imageProbeHosts.includes(hostname) && !imageProbeDomains.some(domain => hostname === domain || hostname.endsWith(`.${domain}`))) {
                     return;
                 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -288,7 +288,7 @@ const commands = {
     },
     l33t: _leet,
     labrat(args, callback) {
-        callback(null, 'https://res.cloudinary.com/mediocre/image/upload/v1537473791/mijjibf0vxdx79wtqrjh.png');
+        callback(null, 'https://media.stores.com/mediocre/image/upload/v1537473791/mijjibf0vxdx79wtqrjh.png');
     },
     leet: _leet,
     lolspeak(args, callback) {
@@ -390,7 +390,7 @@ const commands = {
         callback(null, '(╯°□°）╯︵ ┻━┻');
     },
     vintner(args, callback) {
-        callback(null, 'https://res.cloudinary.com/mediocre/image/upload/v1540480421/joddffo2zrhb1pzxz7le.png');
+        callback(null, 'https://media.stores.com/mediocre/image/upload/v1540480421/joddffo2zrhb1pzxz7le.png');
     },
     youtube(args, callback) {
         // This command requires arguments.

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,6 @@ const imageProbeHosts = [
     '.giphy.com',
     '.tenor.com',
     'd2b8wt72ktn9a2.cloudfront.net',
-    'i.imgur.com',
     'i.ytimg.com',
     'm.media-amazon.com',
     'media.stores.com',
@@ -449,7 +448,7 @@ exports.commandRegExp = /^\/(\w+)[ ]*(.*)/gim;
 
 // Entries are escaped and the pattern is anchored, so a listed host only matches
 // a whole hostname at a label boundary, never part of an unrelated domain.
-exports.imageProbeHostRegExp = new RegExp(`^(?:${imageProbeHosts.map(host => {
+const imageProbeHostRegExp = new RegExp(`^(?:${imageProbeHosts.map(host => {
     const escaped = host.replace(/^\./, '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
     return host.startsWith('.') ? `(?:[^.]+\\.)*${escaped}` : escaped;
@@ -462,7 +461,7 @@ exports.html = {
     convertToLazyLoadedImages: function(html) {
         let imgElements = exports.html.getElementsByTagName(html, 'img');
 
-        if (!imgElements || !imgElements.length) {
+        if (!imgElements?.length) {
             return html;
         }
 
@@ -482,8 +481,7 @@ exports.html = {
             let lazyLoadImgElement = imgElement.replace('height="', 'data-height="').replace('width="', 'data-width="');
             lazyLoadImgElement = lazyLoadImgElement.replace('src="', 'src="' + emptyImage + '" data-src="');
 
-            // Global string replace: http://stackoverflow.com/questions/4371565/can-you-create-javascript-regexes-on-the-fly-using-string-variables
-            html = html.split(imgElement).join(lazyLoadImgElement);
+            html = html.replaceAll(imgElement, lazyLoadImgElement);
         });
 
         return html;
@@ -520,7 +518,7 @@ exports.html = {
     removeImageSizeAttributes: function(html) {
         let imgElements = exports.html.getElementsByTagName(html, 'img');
 
-        if (!imgElements || !imgElements.length) {
+        if (!imgElements?.length) {
             return html;
         }
 
@@ -532,8 +530,7 @@ exports.html = {
             imgElementWithoutSizeAttributes = exports.html.removeAttribute(imgElementWithoutSizeAttributes, 'width');
 
             if (imgElement !== imgElementWithoutSizeAttributes) {
-                // Global string replace: http://stackoverflow.com/questions/4371565/can-you-create-javascript-regexes-on-the-fly-using-string-variables
-                html = html.split(imgElement).join(imgElementWithoutSizeAttributes);
+                html = html.replaceAll(imgElement, imgElementWithoutSizeAttributes);
             }
         });
 
@@ -703,7 +700,7 @@ exports.render = function(markdown, options, callback) {
 
             let imgElements = exports.html.getElementsByTagName(html, 'img');
 
-            if (!imgElements || !imgElements.length) {
+            if (!imgElements?.length) {
                 return callback();
             }
 
@@ -738,7 +735,7 @@ exports.render = function(markdown, options, callback) {
                     return;
                 }
 
-                if (!exports.imageProbeHostRegExp.test(hostname)) {
+                if (!imageProbeHostRegExp.test(hostname)) {
                     return;
                 }
 
@@ -754,8 +751,7 @@ exports.render = function(markdown, options, callback) {
                         attributes = `${attributes} width="${dimensions.width}"`;
                     }
 
-                    // Global string replace: http://stackoverflow.com/questions/4371565/can-you-create-javascript-regexes-on-the-fly-using-string-variables
-                    html = html.split(`src="${src}"`).join(attributes);
+                    html = html.replaceAll(`src="${src}"`, attributes);
                 } catch {
                     return;
                 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -565,198 +565,198 @@ exports.render = function(markdown, options, callback) {
             let html = markdown;
 
             async.series([
-        function _commands(callback) {
-            if (!options.commands) {
-                return callback();
-            }
-
-            // Check for /commands
-            const commandMatches = markdown.match(exports.commandRegExp);
-
-            // If there aren't any /commands, return.
-            if (!commandMatches || !commandMatches.length) {
-                return callback();
-            }
-
-            let commandIndex = 0;
-
-            const lines = markdown.split(/\n/gmi).map(l => {
-                const isCommand = new RegExp(exports.commandRegExp.source, 'gim').test(l);
-
-                return {
-                    commandIndex: isCommand ? commandIndex++ : -1,
-                    markdown: l
-                };
-            });
-
-            async.forEachOf(commandMatches, (commandMatch, index, callback) => {
-                const tokens = new RegExp(exports.commandRegExp.source, 'gim').exec(commandMatch);
-
-                // The command's name is captured in the first match.
-                const commandName = tokens[1];
-                const command = commands[commandName.toLowerCase()];
-
-                // If the /command isn't supported, return.
-                if (!command) {
-                    return callback();
-                }
-
-                // Get the command's arguments.
-                const args = tokens[2];
-
-                // Execute the /command
-                command(args, (err, result) => {
-                    if (err) {
-                        return callback(err);
+                function _commands(callback) {
+                    if (!options.commands) {
+                        return callback();
                     }
 
-                    if (result) {
-                        const line = lines.find(l => l.commandIndex === index);
-                        let replace = `/${commandName}`;
+                    // Check for /commands
+                    const commandMatches = markdown.match(exports.commandRegExp);
 
-                        if (args) {
-                            replace += ` ${args}`;
+                    // If there aren't any /commands, return.
+                    if (!commandMatches || !commandMatches.length) {
+                        return callback();
+                    }
+
+                    let commandIndex = 0;
+
+                    const lines = markdown.split(/\n/gmi).map(l => {
+                        const isCommand = new RegExp(exports.commandRegExp.source, 'gim').test(l);
+
+                        return {
+                            commandIndex: isCommand ? commandIndex++ : -1,
+                            markdown: l
+                        };
+                    });
+
+                    async.forEachOf(commandMatches, (commandMatch, index, callback) => {
+                        const tokens = new RegExp(exports.commandRegExp.source, 'gim').exec(commandMatch);
+
+                        // The command's name is captured in the first match.
+                        const commandName = tokens[1];
+                        const command = commands[commandName.toLowerCase()];
+
+                        // If the /command isn't supported, return.
+                        if (!command) {
+                            return callback();
                         }
 
-                        line.markdown = line.markdown.replace(replace, result);
-                    }
+                        // Get the command's arguments.
+                        const args = tokens[2];
 
+                        // Execute the /command
+                        command(args, (err, result) => {
+                            if (err) {
+                                return callback(err);
+                            }
+
+                            if (result) {
+                                const line = lines.find(l => l.commandIndex === index);
+                                let replace = `/${commandName}`;
+
+                                if (args) {
+                                    replace += ` ${args}`;
+                                }
+
+                                line.markdown = line.markdown.replace(replace, result);
+                            }
+
+                            callback();
+                        });
+                    }, () => {
+                        markdown = lines.map(l => l.markdown).join('\n');
+                        callback();
+                    });
+                },
+                function _bbcode(callback) {
+                    markdown = exports.bbcode.toMarkdown(markdown);
                     callback();
-                });
-            }, () => {
-                markdown = lines.map(l => l.markdown).join('\n');
-                callback();
-            });
-        },
-        function _bbcode(callback) {
-            markdown = exports.bbcode.toMarkdown(markdown);
-            callback();
-        },
-        function _markdown(callback) {
-            const md = new MarkdownIt({
-                baseUrl: options.baseUrl,
-                breaks: true,
-                linkify: true,
-                typographer: true,
-                xhtmlOut: true
-            });
+                },
+                function _markdown(callback) {
+                    const md = new MarkdownIt({
+                        baseUrl: options.baseUrl,
+                        breaks: true,
+                        linkify: true,
+                        typographer: true,
+                        xhtmlOut: true
+                    });
 
-            md.linkify.add('@', require('./plugins/usernames'));
-            md.linkify.baseUrl = options.baseUrl;
-            md.linkify.tlds('horse', true);
-            md.linkify.tlds('deals', true);
+                    md.linkify.add('@', require('./plugins/usernames'));
+                    md.linkify.baseUrl = options.baseUrl;
+                    md.linkify.tlds('horse', true);
+                    md.linkify.tlds('deals', true);
 
-            md.use(require('markdown-it-collapsible'));
-            md.use(require('./plugins/amazon'));
-            md.use(require('./plugins/anchors'), { suffix: options.id });
-            md.use(require('./plugins/appleMusic'));
-            md.use(require('./plugins/audio'));
-            md.use(require('./plugins/emoji'), options.emoji);
-            md.use(require('./plugins/facebook-videos'));
-            md.use(require('./plugins/gist'));
-            md.use(require('./plugins/images'));
-            md.use(require('./plugins/imgur'));
-            md.use(require('./plugins/instagram'));
-            md.use(require('./plugins/kaltura'));
-            md.use(require('./plugins/kickstarter'));
-            md.use(require('./plugins/linkRelTarget'));
-            md.use(require('./plugins/stores-com'));
-            md.use(require('./plugins/reddit'));
-            md.use(require('./plugins/responsiveTables'));
-            md.use(require('./plugins/soundcloud'));
-            md.use(require('./plugins/twitter'));
-            md.use(require('./plugins/video'));
-            md.use(require('./plugins/vimeo'));
-            md.use(require('./plugins/vine'));
-            md.use(require('./plugins/youtube'));
+                    md.use(require('markdown-it-collapsible'));
+                    md.use(require('./plugins/amazon'));
+                    md.use(require('./plugins/anchors'), { suffix: options.id });
+                    md.use(require('./plugins/appleMusic'));
+                    md.use(require('./plugins/audio'));
+                    md.use(require('./plugins/emoji'), options.emoji);
+                    md.use(require('./plugins/facebook-videos'));
+                    md.use(require('./plugins/gist'));
+                    md.use(require('./plugins/images'));
+                    md.use(require('./plugins/imgur'));
+                    md.use(require('./plugins/instagram'));
+                    md.use(require('./plugins/kaltura'));
+                    md.use(require('./plugins/kickstarter'));
+                    md.use(require('./plugins/linkRelTarget'));
+                    md.use(require('./plugins/stores-com'));
+                    md.use(require('./plugins/reddit'));
+                    md.use(require('./plugins/responsiveTables'));
+                    md.use(require('./plugins/soundcloud'));
+                    md.use(require('./plugins/twitter'));
+                    md.use(require('./plugins/video'));
+                    md.use(require('./plugins/vimeo'));
+                    md.use(require('./plugins/vine'));
+                    md.use(require('./plugins/youtube'));
 
-            html = md.render(markdown);
-            html = html.trim();
-            callback();
-        },
-        function _imageSizes(callback) {
-            if (!options.detectImageSizes) {
-                return callback();
-            }
-
-            const imgElements = [...new Set(exports.html.getElementsByTagName(html, 'img'))];
-
-            if (!imgElements.length) {
-                return callback();
-            }
-
-            async.each(imgElements, async imgElement => {
-                const className = exports.html.getAttributeValue(imgElement, 'class');
-
-                // Skip emojis
-                if (['emojione', 'joypixels'].includes(className)) {
-                    return;
-                }
-
-                const src = exports.html.getAttributeValue(imgElement, 'src');
-
-                if (!src) {
-                    return;
-                }
-
-                let url = src;
-
-                if (url.startsWith('//')) {
-                    url = `https:${url}`;
-                }
-
-                let hostname;
-
-                try {
-                    hostname = new URL(url).hostname.toLowerCase();
-                } catch {
-                    return;
-                }
-
-                if (!imageProbeHostRegExp.test(hostname)) {
-                    return;
-                }
-
-                try {
-                    const dimensions = await probeImageSize(url);
-                    let attributes = `src="${src}"`;
-
-                    if (dimensions.height) {
-                        attributes = `height="${dimensions.height}" ${attributes}`;
+                    html = md.render(markdown);
+                    html = html.trim();
+                    callback();
+                },
+                function _imageSizes(callback) {
+                    if (!options.detectImageSizes) {
+                        return callback();
                     }
 
-                    if (dimensions.width) {
-                        attributes = `${attributes} width="${dimensions.width}"`;
+                    const imgElements = [...new Set(exports.html.getElementsByTagName(html, 'img'))];
+
+                    if (!imgElements.length) {
+                        return callback();
                     }
 
-                    html = html.replaceAll(`src="${src}"`, attributes);
-                } catch {
-                    return;
+                    async.each(imgElements, async imgElement => {
+                        const className = exports.html.getAttributeValue(imgElement, 'class');
+
+                        // Skip emojis
+                        if (['emojione', 'joypixels'].includes(className)) {
+                            return;
+                        }
+
+                        const src = exports.html.getAttributeValue(imgElement, 'src');
+
+                        if (!src) {
+                            return;
+                        }
+
+                        let url = src;
+
+                        if (url.startsWith('//')) {
+                            url = `https:${url}`;
+                        }
+
+                        let hostname;
+
+                        try {
+                            hostname = new URL(url).hostname.toLowerCase();
+                        } catch {
+                            return;
+                        }
+
+                        if (!imageProbeHostRegExp.test(hostname)) {
+                            return;
+                        }
+
+                        try {
+                            const dimensions = await probeImageSize(url);
+                            let attributes = `src="${src}"`;
+
+                            if (dimensions.height) {
+                                attributes = `height="${dimensions.height}" ${attributes}`;
+                            }
+
+                            if (dimensions.width) {
+                                attributes = `${attributes} width="${dimensions.width}"`;
+                            }
+
+                            html = html.replaceAll(`src="${src}"`, attributes);
+                        } catch {
+                            return;
+                        }
+                    }, () => {
+                        callback();
+                    });
+                },
+                // https://github.com/markdown-it/markdown-it/issues/1031
+                function _urlEncodeFix(callback) {
+                    const aElements = exports.html.getElementsByTagName(html, 'a');
+
+                    if (!aElements?.length) {
+                        return callback();
+                    }
+
+                    aElements.forEach(aElement => {
+                        const href = exports.html.getAttributeValue(aElement, 'href');
+
+                        if (!href?.includes('&amp;')) {
+                            return;
+                        }
+
+                        html = html.replaceAll(`href="${href}"`, `href="${href.replaceAll('&amp;', '&')}"`);
+                    });
+
+                    return callback();
                 }
-            }, () => {
-                callback();
-            });
-        },
-        // https://github.com/markdown-it/markdown-it/issues/1031
-        function _urlEncodeFix(callback) {
-            const aElements = exports.html.getElementsByTagName(html, 'a');
-
-            if (!aElements?.length) {
-                return callback();
-            }
-
-            aElements.forEach(aElement => {
-                const href = exports.html.getAttributeValue(aElement, 'href');
-
-                if (!href?.includes('&amp;')) {
-                    return;
-                }
-
-                html = html.replaceAll(`href="${href}"`, `href="${href.replaceAll('&amp;', '&')}"`);
-            });
-
-            return callback();
-        }
             ], (err) => {
                 if (err) {
                     return reject(err);

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
         "test": "node --test --test-force-exit --test-reporter=spec",
         "test:only": "node --test --test-force-exit --test-only --test-reporter=spec"
     },
-    "version": "3.0.1"
+    "version": "3.0.2"
 }

--- a/test/imageProbeHosts.js
+++ b/test/imageProbeHosts.js
@@ -1,0 +1,55 @@
+const assert = require('node:assert');
+const test = require('node:test');
+
+// Stand in for the image prober before mehdown loads, so mehdown captures this
+// instead of the real one. Rendering then tells us exactly which hosts it would
+// have made a request to, for hostnames we could not otherwise stand a server up on.
+const probeImageSizePath = require.resolve('probe-image-size');
+
+require(probeImageSizePath);
+
+const requested = [];
+
+require.cache[probeImageSizePath].exports = function(url) {
+    requested.push(url);
+
+    return Promise.resolve({ height: 2, width: 3 });
+};
+
+const mehdown = require('../lib');
+
+async function hostsRequestedFor(hostnames) {
+    requested.length = 0;
+
+    const markdown = hostnames.map(hostname => `![](https://${hostname}/image.png)`).join('\n\n');
+
+    await mehdown.render(markdown, { detectImageSizes: true });
+
+    return requested.map(url => new URL(url).hostname).sort();
+}
+
+test('image probe hosts', async (t) => {
+    t.test('requests images on hosts that are on the list', async () => {
+        const hostnames = ['d2b8wt72ktn9a2.cloudfront.net', 'media.stores.com', 'res.cloudinary.com', 'substackcdn.com', 'upload.wikimedia.org'];
+
+        assert.deepStrictEqual(await hostsRequestedFor(hostnames), hostnames.slice().sort());
+    });
+
+    t.test('requests images on a listed domain and any of its subdomains', async () => {
+        const hostnames = ['giphy.com', 'x.giphy.com', 'media0.giphy.com', 'a.b.giphy.com', 'tenor.com', 'c.tenor.com'];
+
+        assert.deepStrictEqual(await hostsRequestedFor(hostnames), hostnames.slice().sort());
+    });
+
+    t.test('does not request images on a host that only ends with a listed host', async () => {
+        assert.deepStrictEqual(await hostsRequestedFor(['notsubstackcdn.com', 'xsubstackcdn.com', 'xgiphy.com', 'notgiphy.com', 'x-media.stores.com', 'notd2b8wt72ktn9a2.cloudfront.net']), []);
+    });
+
+    t.test('does not request images on a listed host used as the prefix of another domain', async () => {
+        assert.deepStrictEqual(await hostsRequestedFor(['substackcdn.com.example.net', 'giphy.com.example.net', 'res.cloudinary.com.example.net']), []);
+    });
+
+    t.test('does not request images on a subdomain of a listed exact host', async () => {
+        assert.deepStrictEqual(await hostsRequestedFor(['sub.substackcdn.com']), []);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -585,36 +585,6 @@ test('detect image sizes', { concurrency: true }, async (t) => {
     });
 });
 
-test('imageProbeHostRegExp', { concurrency: true }, async (t) => {
-    t.test('matches hosts on the list', () => {
-        for (const hostname of ['d2b8wt72ktn9a2.cloudfront.net', 'i.imgur.com', 'media.stores.com', 'res.cloudinary.com', 'substackcdn.com', 'upload.wikimedia.org']) {
-            assert.ok(mehdown.imageProbeHostRegExp.test(hostname), `expected ${hostname} to match`);
-        }
-    });
-
-    t.test('matches a listed domain and any of its subdomains', () => {
-        for (const hostname of ['giphy.com', 'x.giphy.com', 'media0.giphy.com', 'a.b.giphy.com', 'tenor.com', 'c.tenor.com']) {
-            assert.ok(mehdown.imageProbeHostRegExp.test(hostname), `expected ${hostname} to match`);
-        }
-    });
-
-    t.test('does not match a host that only ends with a listed host', () => {
-        for (const hostname of ['notsubstackcdn.com', 'xsubstackcdn.com', 'xgiphy.com', 'notgiphy.com', 'x-media.stores.com', 'notd2b8wt72ktn9a2.cloudfront.net']) {
-            assert.ok(!mehdown.imageProbeHostRegExp.test(hostname), `expected ${hostname} not to match`);
-        }
-    });
-
-    t.test('does not match a listed host used as the prefix of another domain', () => {
-        for (const hostname of ['substackcdn.com.example.net', 'giphy.com.example.net', 'res.cloudinary.com.example.net']) {
-            assert.ok(!mehdown.imageProbeHostRegExp.test(hostname), `expected ${hostname} not to match`);
-        }
-    });
-
-    t.test('does not match a subdomain of a listed exact host', () => {
-        assert.ok(!mehdown.imageProbeHostRegExp.test('sub.substackcdn.com'));
-    });
-});
-
 test('email', { concurrency: true }, async (t) => {
     t.test('email address', async () => {
         const html = await render('email me at whatever@somewhere.com if you are not a meanie.');

--- a/test/index.js
+++ b/test/index.js
@@ -585,6 +585,36 @@ test('detect image sizes', { concurrency: true }, async (t) => {
     });
 });
 
+test('imageProbeHostRegExp', { concurrency: true }, async (t) => {
+    t.test('matches hosts on the list', () => {
+        for (const hostname of ['d2b8wt72ktn9a2.cloudfront.net', 'i.imgur.com', 'media.stores.com', 'res.cloudinary.com', 'substackcdn.com', 'upload.wikimedia.org']) {
+            assert.ok(mehdown.imageProbeHostRegExp.test(hostname), `expected ${hostname} to match`);
+        }
+    });
+
+    t.test('matches a listed domain and any of its subdomains', () => {
+        for (const hostname of ['giphy.com', 'x.giphy.com', 'media0.giphy.com', 'a.b.giphy.com', 'tenor.com', 'c.tenor.com']) {
+            assert.ok(mehdown.imageProbeHostRegExp.test(hostname), `expected ${hostname} to match`);
+        }
+    });
+
+    t.test('does not match a host that only ends with a listed host', () => {
+        for (const hostname of ['notsubstackcdn.com', 'xsubstackcdn.com', 'xgiphy.com', 'notgiphy.com', 'x-media.stores.com', 'notd2b8wt72ktn9a2.cloudfront.net']) {
+            assert.ok(!mehdown.imageProbeHostRegExp.test(hostname), `expected ${hostname} not to match`);
+        }
+    });
+
+    t.test('does not match a listed host used as the prefix of another domain', () => {
+        for (const hostname of ['substackcdn.com.example.net', 'giphy.com.example.net', 'res.cloudinary.com.example.net']) {
+            assert.ok(!mehdown.imageProbeHostRegExp.test(hostname), `expected ${hostname} not to match`);
+        }
+    });
+
+    t.test('does not match a subdomain of a listed exact host', () => {
+        assert.ok(!mehdown.imageProbeHostRegExp.test('sub.substackcdn.com'));
+    });
+});
+
 test('email', { concurrency: true }, async (t) => {
     t.test('email address', async () => {
         const html = await render('email me at whatever@somewhere.com if you are not a meanie.');

--- a/test/index.js
+++ b/test/index.js
@@ -215,7 +215,7 @@ test('commands', { concurrency: true }, async (t) => {
 
     t.test('/labrat', async () => {
         const html = await render('/labrat');
-        assert.strictEqual(html, '<p><img src="https://res.cloudinary.com/mediocre/image/upload/v1537473791/mijjibf0vxdx79wtqrjh.png" /></p>');
+        assert.strictEqual(html, '<p><img src="https://media.stores.com/mediocre/image/upload/v1537473791/mijjibf0vxdx79wtqrjh.png" /></p>');
     });
 
     t.test('/leet', { concurrency: true }, async (t) => {
@@ -414,7 +414,7 @@ test('commands', { concurrency: true }, async (t) => {
 
     t.test('/vintner', async () => {
         const html = await render('/vintner');
-        assert.strictEqual(html, '<p><img src="https://res.cloudinary.com/mediocre/image/upload/v1540480421/joddffo2zrhb1pzxz7le.png" /></p>');
+        assert.strictEqual(html, '<p><img src="https://media.stores.com/mediocre/image/upload/v1540480421/joddffo2zrhb1pzxz7le.png" /></p>');
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -538,6 +538,11 @@ test('detect image sizes', { concurrency: true }, async (t) => {
         }
     });
 
+    t.test('image on a subdomain of an allowed domain', async () => {
+        const html = await render('https://media0.giphy.com/media/3o7TKvGA0JJ9l33nLa/giphy.gif', { detectImageSizes: true });
+        assert.strictEqual(html, '<p><img height="270" src="https://media0.giphy.com/media/3o7TKvGA0JJ9l33nLa/giphy.gif" width="384" /></p>');
+    });
+
     t.test('images', async () => {
         const html = await render('https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png', { detectImageSizes: true });
         assert.strictEqual(html, '<p><img height="528" src="https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png" width="528" /> <img height="528" src="https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png" width="528" /></p>');


### PR DESCRIPTION
The first pass at this list was drawn from a few hundred topics. That sample turned out to skew years old and badly misrepresent what people actually post.

Measured properly this time — a year of topics, comments and replies: **80,116 documents, 12,412 non-emoji images, 308 distinct hosts**. The previous list covered **53.9%**, and two of its four entries matched nothing at all:

| Previous entry | Images in a year |
|---|---|
| `res.cloudinary.com` | 6,625 |
| `media.stores.com` | 60 |
| `i.imgur.com` | **0** |
| `static.meh.com` | **0** |

(`i.imgur.com` was 55 of 138 images in the older sample — it's zero over the last year.)

### The biggest gap was our own CDN

`d2b8wt72ktn9a2.cloudfront.net` — the distribution `media.stores.com` CNAMEs to — accounts for **3,416 images, 27.5% of the total**, because content references the distribution hostname directly rather than the branded domain. All of those were silently losing their dimensions.

### Subdomain matching

Some hosts shard across many subdomains — Giphy uses six. Rather than enumerate them, `imageProbeDomains` matches subdomains as well. It requires a leading dot, so a domain can only match at a label boundary:

```
PROBE  media0.giphy.com    skip  notgiphy.com
PROBE  media.giphy.com     skip  evilgiphy.com
PROBE  giphy.com           skip  giphy.com.attacker.net
PROBE  media.tenor.com     skip  giphy.company
```

That rule also picked up `c.tenor.com` and bare `tenor.com`, which an explicit list would have missed.

### Result

Coverage goes from **53.9% to 95.9%** — 5,217 images that previously got no dimensions now do. The remainder is a real long tail: 242 hosts appear exactly once, together under 2% of images, so there's no list that reaches 100%.

### Tests

New test renders an image on a Giphy subdomain and asserts the dimensions come back, written first and confirmed failing before the change. Uses a URL form without expiring query tokens so it won't rot. The existing loopback test still guards the other direction.

348 pass, 0 fail, ESLint clean.

### Note

Allowlisting a raw CloudFront hostname is brittle — recreating a distribution changes it. Unavoidable here since the URL is already stored in 3,207 documents, but those would ideally be normalised to `media.stores.com` at some point.

Version bumped to **3.0.2**.